### PR TITLE
fix(stream): Detect default by codec, not `default_stream`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@napi-audio/monorepo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This better handles multi-stream files, and matches symphonia-play behavior.