### PR TITLE
fix(decoder-cleanup): [NON-BREAKING] Internal cleaup of rust decoder

### DIFF
--- a/packages/decoder/src/internal/error.rs
+++ b/packages/decoder/src/internal/error.rs
@@ -1,0 +1,14 @@
+use symphonia::core::errors::Error as SymphoniaError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+  #[error(transparent)]
+  Symphonia(#[from] SymphoniaError),
+  #[error("The decoder was reset, please try again")]
+  ResetRequired,
+  #[error("The decoder is waiting for additional data, please try again")]
+  InsufficientData,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/packages/decoder/src/internal/io.rs
+++ b/packages/decoder/src/internal/io.rs
@@ -1,0 +1,105 @@
+use std::{
+  fmt::{Debug, Display},
+  io::{Error as IoError, ErrorKind as IoErrorKind, Read},
+  ops::Deref,
+};
+
+use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub struct EndMarkerError;
+
+impl Display for EndMarkerError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("EndMarkerError").finish()
+  }
+}
+
+pub struct CrossbeamData(pub Vec<u8>);
+
+impl Deref for CrossbeamData {
+  type Target = Vec<u8>;
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl Debug for CrossbeamData {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("CrossbeamData")
+      .field("len", &self.len())
+      .finish_non_exhaustive()
+  }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CrossbeamChunk {
+  Data(Vec<u8>),
+  End,
+}
+
+#[derive(Clone)]
+pub struct CrossbeamReader {
+  rx: Receiver<CrossbeamChunk>,
+  offset: usize,
+  buffer: Vec<u8>,
+}
+
+impl Read for CrossbeamReader {
+  fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+    while self.offset >= self.buffer.len() {
+      if self.rx.is_empty() {
+        return Err(IoError::new(
+          IoErrorKind::UnexpectedEof,
+          "No data available for reading at this time",
+        ));
+      }
+
+      self.buffer = match self.rx.recv() {
+        Ok(v) => match v {
+          CrossbeamChunk::Data(v) => v,
+          CrossbeamChunk::End => return Err(IoError::other(EndMarkerError)),
+        },
+        Err(err) => return Err(IoError::new(IoErrorKind::NotConnected, err)),
+      };
+      self.offset = 0;
+    }
+    let size = std::cmp::min(buf.len(), self.buffer.len() - self.offset);
+    buf[..size].copy_from_slice(&self.buffer[self.offset..self.offset + size]);
+    self.offset += size;
+    Ok(size)
+  }
+}
+
+impl Debug for CrossbeamReader {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("CrossbeamReader")
+      .field("rx", &self.rx)
+      .field("offset", &self.offset)
+      .field("len", &self.len())
+      .finish_non_exhaustive()
+  }
+}
+
+impl CrossbeamReader {
+  pub fn len(&self) -> usize {
+    self.buffer.len()
+  }
+
+  pub fn new(capacity: Option<usize>) -> (Sender<CrossbeamChunk>, Self) {
+    let (tx, rx) = match capacity {
+      Some(capacity) => bounded(capacity),
+      None => unbounded(),
+    };
+
+    (
+      tx,
+      Self {
+        rx,
+        offset: 0,
+        buffer: Vec::new(),
+      },
+    )
+  }
+}

--- a/packages/decoder/src/internal/mod.rs
+++ b/packages/decoder/src/internal/mod.rs
@@ -1,0 +1,35 @@
+use symphonia::{
+  core::{
+    formats::FormatOptions,
+    io::MediaSourceStream,
+    meta::{Limit, MetadataOptions},
+    probe::{Hint, ProbeResult},
+  },
+  default::get_probe,
+};
+
+use error::Result;
+
+pub mod decoder;
+pub mod error;
+pub mod io;
+
+pub fn try_probe_format(
+  mss: MediaSourceStream,
+  hint: &Hint,
+  format_options: &FormatOptions,
+) -> Result<ProbeResult> {
+  let probe = get_probe();
+
+  let result = probe.format(
+    hint,
+    mss,
+    format_options,
+    &MetadataOptions {
+      limit_visual_bytes: Limit::Maximum(0),
+      ..Default::default()
+    },
+  )?;
+
+  Ok(result)
+}

--- a/packages/decoder/src/lib.rs
+++ b/packages/decoder/src/lib.rs
@@ -3,7 +3,11 @@
 use std::io::BufReader;
 
 use crossbeam_channel::Sender;
-use decode::{try_probe_format, CrossbeamChunk, CrossbeamReader, Decoder as PlatformDecoder};
+use internal::{
+  decoder::Decoder as PlatformDecoder,
+  io::{CrossbeamChunk, CrossbeamReader},
+  try_probe_format,
+};
 use napi::{
   self,
   bindgen_prelude::{BufferSlice, Int16Array},
@@ -17,7 +21,9 @@ use tracing::{debug, info};
 use tracing_log::LogTracer;
 use tracing_subscriber::{EnvFilter, FmtSubscriber};
 
-mod decode;
+use crate::internal::error::Error;
+
+mod internal;
 
 #[macro_use]
 extern crate napi_derive;
@@ -217,7 +223,7 @@ impl Decoder {
             decoded_sample.append(&mut data);
           }
           Err(ref err) => {
-            if matches!(err, decode::Error::InsufficientData) {
+            if matches!(err, Error::InsufficientData) {
               break;
             }
           }

--- a/packages/decoder/src/lib.rs
+++ b/packages/decoder/src/lib.rs
@@ -198,7 +198,6 @@ impl Decoder {
       let mut decoded_spec = None;
       let mut decoded_sample = Vec::new();
 
-      // TODO(bengreenier): this blocks when we run out of shit to read
       for maybe_sample_result in decoder.iter_mut::<i16>() {
         debug!("attempting to process next sample");
 


### PR DESCRIPTION
This is a first pass at addressing #1 - it does not change the public API at all, nor the internal behavior - it's only code cleanup